### PR TITLE
fix Miniconda version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
 node {
+    def PYTHON_VERSION = "3.5"
+    def CONDA_VERSION = "4.1.11"
     stage 'setup'
 
         // Download the miniconda tool
-        sh 'curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh'
+        sh "curl https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -o miniconda.sh"
 
         // Make the tool executable
         sh 'chmod +x ./miniconda.sh'


### PR DESCRIPTION
It would appear that a new version of Miniconda was uploaded today (between me raising the PR and your merge). Unfortunately that had a breaking change.

This PR fixes the version of Miniconda to use with the build process. Latest (4.2.11) currently includes version 2.11.1 of Request module which has breaking changes. I have switched to version 4.1.11 which includes version 2.10.1 of Request, and is working.

That was rather unfortunate!